### PR TITLE
Add voucher product type to service container

### DIFF
--- a/src/Bootstrap/Services.php
+++ b/src/Bootstrap/Services.php
@@ -112,5 +112,11 @@ class Services implements ServicesInterface
 				->run()
 				->flatten();
 		});
+
+		$services['product.types'] = $services->extend('product.types', function ($types, $c) {
+			$types->add(new Voucher\ProductType\VoucherType);
+
+			return $types;
+		});
 	}
 }

--- a/src/Bootstrap/Tasks.php
+++ b/src/Bootstrap/Tasks.php
@@ -10,6 +10,7 @@ class Tasks implements TasksInterface
     public function registerTasks($tasks)
     {
         $tasks->add(new Task\Porting\Voucher('vouchers:porting:port_vouchers'), 'Ports gift voucher data from pre mothership');
+        $tasks->add(new Task\UpdateVoucherProductTypes('vouchers:set_product_types'), 'Sets product types for vouchers in config');
 
     }
 }

--- a/src/Task/UpdateVoucherProductTypes.php
+++ b/src/Task/UpdateVoucherProductTypes.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Message\Mothership\Voucher\Task;
+
+use Message\Mothership\Voucher\ProductType\VoucherType;
+use Message\Cog\Console\Task\Task;
+
+/**
+ * Class UpdateVoucherProductTypes
+ * @package Message\Mothership\Voucher\Task
+ *
+ * @author Thomas Marchant <thomas@message.co.uk>
+ *
+ * Set voucher products from old configs to have a type of 'voucher'
+ */
+class UpdateVoucherProductTypes extends Task
+{
+	public function process()
+	{
+		if (empty($this->get('cfg')->voucher) || empty($this->get('cfg')->voucher->productIDs)) {
+			$this->writeln('<info>No voucher product IDs found</info>');
+		}
+
+		$productIDs = (array) $this->get('cfg')->voucher->productIDs;
+
+		$this->writeln('Voucher product IDs: ' . implode(', ', $productIDs));
+
+		$this->writeln('Running query');
+
+		$this->get('db.query')->run("
+			UPDATE
+				product
+			SET
+				type = :type?s
+			WHERE
+				product_id IN (:productIDs?ji)
+		", [
+			'type'       => VoucherType::TYPE_NAME,
+			'productIDs' => $productIDs,
+		]);
+
+		$this->writeln('Update complete');
+	}
+}


### PR DESCRIPTION
#### What does this do?

Adds the voucher product type to the service container and includes a task for updating existing voucher products to use the voucher type.
#### How should this be manually tested?

Run the task `vouchers:set_product_types` and check that any voucher products on an installation are set to a voucher product type, and work
#### Related PRs / Issues / Resources?
#### Anything else to add? (Screenshots, background context, etc)
