### PR TITLE
Allow slashes in voucher urls

### DIFF
--- a/resources/view/control-panel/index.html.twig
+++ b/resources/view/control-panel/index.html.twig
@@ -23,7 +23,7 @@
 			<tbody>
 				{% for voucher in vouchers %}
 				<tr>
-					<td><a href="{{ url('ms.cp.voucher.view', {id : voucher.id}) }}">{{ voucher.id }}</a></td>
+					<td><a href="{{ url('ms.cp.voucher.view', {id : voucher.id | url_encode}) }}">{{ voucher.id }}</a></td>
 					<td>{{ voucher.authorship.createdAt|date }}</td>
 					<td>{{ voucher.amount|price(voucher.currencyID) }}</td>
 					<td>{{ voucher.getBalance()|price(voucher.currencyID) }}</td>

--- a/resources/view/control-panel/view.html.twig
+++ b/resources/view/control-panel/view.html.twig
@@ -8,7 +8,7 @@
 	<div class="title vouchers">
 		<h1>Voucher '{{ voucher.id }}' <span>{{ 'ms.voucher.expiry.label'|trans }} {{ voucher.expiresAt is empty ? 'Never' : voucher.expiresAt|date }}</span></h1>
 		<div class="controls">
-		    <form action="{{ url('ms.cp.voucher.invalidate', {id: voucher.id}) }}" method="post" id="delete-page">
+		    <form action="{{ url('ms.cp.voucher.invalidate', {id: (voucher.id | url_encode)}) }}" method="post" id="delete-page">
 		        <input type="hidden" name="_method" value="DELETE">
 		        <button name="delete[delete]" value="delete" id="delete" type="submit" class="button small delete">{{ 'Invalidate Voucher'|trans }}</button>
 		    </form>

--- a/src/Bootstrap/Routes.php
+++ b/src/Bootstrap/Routes.php
@@ -20,7 +20,7 @@ class Routes implements RoutesInterface
 			->setMethod('POST');
 
 		$router['ms.cp.voucher']->add('ms.cp.voucher.invalidate', '/{id}/invalidate', 'Message:Mothership:Voucher::Controller:ControlPanel#invalidate')
-			->setRequirement('id', '[A-Z0-9]+')
+			->setRequirement('id', '[A-Z0-9/.]+')
 			->setMethod('DELETE');
 
 		$router['ms.cp.voucher']->add('ms.cp.voucher.view', '/{id}', 'Message:Mothership:Voucher::Controller:ControlPanel#view');

--- a/src/Bootstrap/Routes.php
+++ b/src/Bootstrap/Routes.php
@@ -20,10 +20,11 @@ class Routes implements RoutesInterface
 			->setMethod('POST');
 
 		$router['ms.cp.voucher']->add('ms.cp.voucher.invalidate', '/{id}/invalidate', 'Message:Mothership:Voucher::Controller:ControlPanel#invalidate')
-			->setRequirement('id', '[A-Z0-9/.]+')
+			->setRequirement('id', '[A-Z0-9%.]+')
 			->setMethod('DELETE');
 
-		$router['ms.cp.voucher']->add('ms.cp.voucher.view', '/{id}', 'Message:Mothership:Voucher::Controller:ControlPanel#view');
+		$router['ms.cp.voucher']->add('ms.cp.voucher.view', '/{id}', 'Message:Mothership:Voucher::Controller:ControlPanel#view')
+			->setRequirement('id', '[A-Z0-9%.]+');
 
 		$router['ms.epos.sale.modal']->add('ms.epos.sale.modal.tender.voucher.search', '/tender/voucher/{type}', 'Message:Mothership:Voucher::Controller:Epos#findVoucher')
 			->setMethod('POST');

--- a/src/Controller/ControlPanel.php
+++ b/src/Controller/ControlPanel.php
@@ -43,6 +43,9 @@ class ControlPanel extends Controller
 
 	public function view($id)
 	{
+		// Some voucher codes have slashes in them so we need to encode/decode the ID
+		$id = urldecode($id);
+
 		$voucher            = $this->get('voucher.loader')->getByID($id);
 		$orderPayments      = [];
 		$orderPaymentLoader = $this->get('order.payment.loader');

--- a/src/Controller/ControlPanel.php
+++ b/src/Controller/ControlPanel.php
@@ -110,6 +110,8 @@ class ControlPanel extends Controller
 
 	public function invalidate($id)
 	{
+		$id = urldecode($id);
+
 		$voucher = $this->get('voucher.loader')->getByID($id);
 
 		$this->get('voucher.edit')->setExpiry($voucher, new \DateTime);


### PR DESCRIPTION
There is currently an <a href="https://github.com/mothership-ec/cog/issues/449">issue</a> with the string generator in Cog where it can ignore the the given regex to use a list of all alphanumeric characters plus a full stop and a forward slash. This means that some vouchers have been generated to contain characters not declared in the regex, i.e. the forward slash. This in turn broke the URLs in the admin panel. This change fixes that.