### PR TITLE
Use `allowChars()` when generating voucher IDs

### DIFF
--- a/src/IdGenerator.php
+++ b/src/IdGenerator.php
@@ -37,9 +37,11 @@ class IdGenerator
 	 */
 	public function generate()
 	{
+		$allowChars = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
 		do {
-			$id = $this->_stringGenerator->setPattern('/^[A-HJ-KM-NP-Z2-9]+$/')->generate($this->_length);
-		} while($this->_idExists($id));
+			$id = $this->_stringGenerator->allowChars($allowChars)->generate($this->_length);
+		} while ($this->_idExists($id));
 
 		return $id;
 	}


### PR DESCRIPTION
As a result of https://github.com/mothership-ec/cog/issues/449, slashes and dots, as well as characters that look similar to each other, were appearing in voucher codes. This PR reverts to expected behaviour when generating voucher strings using the new `StringGenerator::allowChars()` method. Requires https://github.com/mothership-ec/cog/pull/465