### PR TITLE
Send e-voucher on order creation instead of voucher creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+
+install:
+  - composer install --prefer-source
+
+script:
+  - phpunit
+
+notifications:
+  email: false

--- a/composer.lock
+++ b/composer.lock
@@ -1549,14 +1549,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony EventDispatcher Component",
@@ -1648,14 +1646,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Finder Component",
@@ -2019,14 +2015,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Process Component",
@@ -2185,14 +2179,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Templating Component",
@@ -2482,14 +2474,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony Yaml Component",

--- a/composer.lock
+++ b/composer.lock
@@ -5,6 +5,7 @@
         "This file is @generated automatically"
     ],
     "hash": "0f458cb2023af851389ba6d605957bb3",
+    "content-hash": "cbf75f129cced08e1987683404e308d2",
     "packages": [
         {
             "name": "dflydev/markdown",
@@ -169,16 +170,16 @@
         },
         {
             "name": "imagine/imagine",
-            "version": "0.6.2",
+            "version": "v0.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/avalanche123/Imagine.git",
-                "reference": "83ca8babede0e54f935ec09d55a726bf4b0a3f7c"
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/83ca8babede0e54f935ec09d55a726bf4b0a3f7c",
-                "reference": "83ca8babede0e54f935ec09d55a726bf4b0a3f7c",
+                "url": "https://api.github.com/repos/avalanche123/Imagine/zipball/149041d2a1b517107bfe270ca2b1a17aa341715d",
+                "reference": "149041d2a1b517107bfe270ca2b1a17aa341715d",
                 "shasum": ""
             },
             "require": {
@@ -222,7 +223,7 @@
                 "image manipulation",
                 "image processing"
             ],
-            "time": "2014-11-11 11:36:02"
+            "time": "2015-09-19 16:54:05"
         },
         {
             "name": "itbz/fpdf",
@@ -676,16 +677,16 @@
         },
         {
             "name": "mothership-ec/cog",
-            "version": "4.11.0",
+            "version": "4.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog.git",
-                "reference": "a36a5e0c98458aeb6a152ad38c8c8a78e13d5fe8"
+                "reference": "c8b2abf0674d0d6ae2a6ee0ada9390143bba254e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/a36a5e0c98458aeb6a152ad38c8c8a78e13d5fe8",
-                "reference": "a36a5e0c98458aeb6a152ad38c8c8a78e13d5fe8",
+                "url": "https://api.github.com/repos/mothership-ec/cog/zipball/c8b2abf0674d0d6ae2a6ee0ada9390143bba254e",
+                "reference": "c8b2abf0674d0d6ae2a6ee0ada9390143bba254e",
                 "shasum": ""
             },
             "require": {
@@ -767,20 +768,20 @@
                 "cog",
                 "framework"
             ],
-            "time": "2015-09-23 13:13:32"
+            "time": "2015-11-17 16:42:42"
         },
         {
             "name": "mothership-ec/cog-imageresize",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-imageresize.git",
-                "reference": "4987d2ce1d2470683540c91873cf88c598798990"
+                "reference": "11f62c0bdfd9e452b76e85857e85e9cb392345a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-imageresize/zipball/4987d2ce1d2470683540c91873cf88c598798990",
-                "reference": "4987d2ce1d2470683540c91873cf88c598798990",
+                "url": "https://api.github.com/repos/mothership-ec/cog-imageresize/zipball/11f62c0bdfd9e452b76e85857e85e9cb392345a0",
+                "reference": "11f62c0bdfd9e452b76e85857e85e9cb392345a0",
                 "shasum": ""
             },
             "require": {
@@ -800,7 +801,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "proprietary"
+                "GPL-3.0+"
             ],
             "authors": [
                 {
@@ -815,25 +816,25 @@
                 "resize",
                 "thumbnail"
             ],
-            "time": "2015-02-24 15:42:16"
+            "time": "2015-09-29 11:30:04"
         },
         {
             "name": "mothership-ec/cog-mothership-commerce",
-            "version": "5.14.0",
+            "version": "5.16.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-commerce.git",
-                "reference": "32d9c57e7aabc89fa49a55f23cf6316e3eb6f266"
+                "reference": "209ca4070f78db7d9ceb068761e4fa5e025c6877"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-commerce/zipball/32d9c57e7aabc89fa49a55f23cf6316e3eb6f266",
-                "reference": "32d9c57e7aabc89fa49a55f23cf6316e3eb6f266",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-commerce/zipball/209ca4070f78db7d9ceb068761e4fa5e025c6877",
+                "reference": "209ca4070f78db7d9ceb068761e4fa5e025c6877",
                 "shasum": ""
             },
             "require": {
                 "domisys/image_barcode2": "3.0.0",
-                "mothership-ec/cog": "~4.9",
+                "mothership-ec/cog": "~4.10",
                 "mothership-ec/cog-imageresize": "~2.0",
                 "mothership-ec/cog-mothership-cp": "~3.2",
                 "mothership-ec/cog-mothership-file-manager": "~3.1",
@@ -872,20 +873,20 @@
                 "orders",
                 "products"
             ],
-            "time": "2015-09-18 16:27:48"
+            "time": "2015-11-18 12:03:50"
         },
         {
             "name": "mothership-ec/cog-mothership-cp",
-            "version": "3.4.3",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-cp.git",
-                "reference": "e19312e16e98d0cd9dfc64a6aa7ab13a5140f699"
+                "reference": "a196d8d37317fd6ceafaab9915aef2863f665c46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/e19312e16e98d0cd9dfc64a6aa7ab13a5140f699",
-                "reference": "e19312e16e98d0cd9dfc64a6aa7ab13a5140f699",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-cp/zipball/a196d8d37317fd6ceafaab9915aef2863f665c46",
+                "reference": "a196d8d37317fd6ceafaab9915aef2863f665c46",
                 "shasum": ""
             },
             "require": {
@@ -922,7 +923,7 @@
                 "control panel",
                 "mothership"
             ],
-            "time": "2015-07-09 15:20:47"
+            "time": "2015-10-23 15:07:49"
         },
         {
             "name": "mothership-ec/cog-mothership-file-manager",
@@ -979,16 +980,16 @@
         },
         {
             "name": "mothership-ec/cog-mothership-reports",
-            "version": "2.0.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-reports.git",
-                "reference": "c6ffc5dde5174e2336e08a45ecd8d467ae79cf33"
+                "reference": "f1a6fe7556b0072e41a34c292f1c99c710730091"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-reports/zipball/c6ffc5dde5174e2336e08a45ecd8d467ae79cf33",
-                "reference": "c6ffc5dde5174e2336e08a45ecd8d467ae79cf33",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-reports/zipball/f1a6fe7556b0072e41a34c292f1c99c710730091",
+                "reference": "f1a6fe7556b0072e41a34c292f1c99c710730091",
                 "shasum": ""
             },
             "require": {
@@ -1023,20 +1024,20 @@
                 "reports",
                 "stats"
             ],
-            "time": "2015-02-24 15:06:23"
+            "time": "2015-10-07 09:50:19"
         },
         {
             "name": "mothership-ec/cog-mothership-user",
-            "version": "4.2.1",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mothership-ec/cog-mothership-user.git",
-                "reference": "1f146f6a3e8f585383631a2ddc8f71317719359f"
+                "reference": "c8d87d90d0906044554f7fc52fe39b93c36f566e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/1f146f6a3e8f585383631a2ddc8f71317719359f",
-                "reference": "1f146f6a3e8f585383631a2ddc8f71317719359f",
+                "url": "https://api.github.com/repos/mothership-ec/cog-mothership-user/zipball/c8d87d90d0906044554f7fc52fe39b93c36f566e",
+                "reference": "c8d87d90d0906044554f7fc52fe39b93c36f566e",
                 "shasum": ""
             },
             "require": {
@@ -1044,7 +1045,7 @@
                 "mothership-ec/cog": "~4.9",
                 "mothership-ec/cog-mothership-cp": "~3.0",
                 "mothership-ec/cog-mothership-file-manager": "~3.0",
-                "mothership-ec/cog-mothership-reports": "~2.0",
+                "mothership-ec/cog-mothership-reports": "~2.2",
                 "mothership-ec/cog-user": "~2.0",
                 "php": ">=5.4.0"
             },
@@ -1074,7 +1075,7 @@
                 "mothership",
                 "user"
             ],
-            "time": "2015-09-16 10:45:17"
+            "time": "2015-11-24 10:43:56"
         },
         {
             "name": "mothership-ec/cog-user",
@@ -1168,16 +1169,16 @@
         },
         {
             "name": "natxet/CssMin",
-            "version": "3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/natxet/CssMin.git",
-                "reference": "f076e41392b0008efb47074a133ec1d90dc8c99f"
+                "reference": "92de3fe3ccb4f8298d31952490ef7d5395855c39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/natxet/CssMin/zipball/f076e41392b0008efb47074a133ec1d90dc8c99f",
-                "reference": "f076e41392b0008efb47074a133ec1d90dc8c99f",
+                "url": "https://api.github.com/repos/natxet/CssMin/zipball/92de3fe3ccb4f8298d31952490ef7d5395855c39",
+                "reference": "92de3fe3ccb4f8298d31952490ef7d5395855c39",
                 "shasum": ""
             },
             "require": {
@@ -1211,7 +1212,7 @@
                 "css",
                 "minify"
             ],
-            "time": "2015-05-21 16:53:45"
+            "time": "2015-09-25 11:13:11"
         },
         {
             "name": "nikic/php-parser",
@@ -1397,16 +1398,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.4",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
-                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
+                "url": "https://github.com/symfony/console.git",
+                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
-                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/16bb1cb86df43c90931df65f529e7ebd79636750",
+                "reference": "16bb1cb86df43c90931df65f529e7ebd79636750",
                 "shasum": ""
             },
             "require": {
@@ -1415,7 +1416,6 @@
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/event-dispatcher": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/process": "~2.1"
             },
             "suggest": {
@@ -1432,7 +1432,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1450,20 +1453,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 11:40:38"
+            "time": "2015-11-18 09:54:26"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.7.4",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Debug.git",
-                "reference": "726bf9651d29f53243281d0b6418cfaa5e318281"
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "0dbc119596f4afc82d9b2eb2a7e6a4af1ee763fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Debug/zipball/726bf9651d29f53243281d0b6418cfaa5e318281",
-                "reference": "726bf9651d29f53243281d0b6418cfaa5e318281",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/0dbc119596f4afc82d9b2eb2a7e6a4af1ee763fa",
+                "reference": "0dbc119596f4afc82d9b2eb2a7e6a4af1ee763fa",
                 "shasum": ""
             },
             "require": {
@@ -1475,8 +1478,7 @@
             },
             "require-dev": {
                 "symfony/class-loader": "~2.2",
-                "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/http-kernel": "~2.3.24|~2.5.9|~2.6,>=2.6.2"
             },
             "type": "library",
             "extra": {
@@ -1487,7 +1489,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Debug\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1505,7 +1510,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-29 11:12:16"
+            "time": "2015-10-30 20:10:21"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -1513,12 +1518,12 @@
             "target-dir": "Symfony/Component/EventDispatcher",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
                 "reference": "e1d18ff0ff6f3e45ac82f000bc221135df635527"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/e1d18ff0ff6f3e45ac82f000bc221135df635527",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e1d18ff0ff6f3e45ac82f000bc221135df635527",
                 "reference": "e1d18ff0ff6f3e45ac82f000bc221135df635527",
                 "shasum": ""
             },
@@ -1560,24 +1565,21 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/Filesystem",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
-                "reference": "2d4e4e21e2b5e4720555811fe8f4a8873cfa0f0f"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d72d4b276921c2388ac09a5a6716e10d57a6e89b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/2d4e4e21e2b5e4720555811fe8f4a8873cfa0f0f",
-                "reference": "2d4e4e21e2b5e4720555811fe8f4a8873cfa0f0f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d72d4b276921c2388ac09a5a6716e10d57a6e89b",
+                "reference": "d72d4b276921c2388ac09a5a6716e10d57a6e89b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
@@ -1588,7 +1590,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1606,7 +1611,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-29 10:34:03"
+            "time": "2015-11-18 08:19:46"
         },
         {
             "name": "symfony/finder",
@@ -1614,12 +1619,12 @@
             "target-dir": "Symfony/Component/Finder",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Finder.git",
+                "url": "https://github.com/symfony/finder.git",
                 "reference": "0fbb7672173a7caab9d266dd26de94b6bc044918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Finder/zipball/0fbb7672173a7caab9d266dd26de94b6bc044918",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0fbb7672173a7caab9d266dd26de94b6bc044918",
                 "reference": "0fbb7672173a7caab9d266dd26de94b6bc044918",
                 "shasum": ""
             },
@@ -1659,17 +1664,17 @@
         },
         {
             "name": "symfony/form",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/Form",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Form.git",
-                "reference": "88aaa1303a2ea0d9709ce8a97bd72888f2788caa"
+                "url": "https://github.com/symfony/form.git",
+                "reference": "ae55dcd67d5f3f8614bf212e9083382179c9bbb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Form/zipball/88aaa1303a2ea0d9709ce8a97bd72888f2788caa",
-                "reference": "88aaa1303a2ea0d9709ce8a97bd72888f2788caa",
+                "url": "https://api.github.com/repos/symfony/form/zipball/ae55dcd67d5f3f8614bf212e9083382179c9bbb0",
+                "reference": "ae55dcd67d5f3f8614bf212e9083382179c9bbb0",
                 "shasum": ""
             },
             "require": {
@@ -1682,7 +1687,6 @@
             "require-dev": {
                 "doctrine/collections": "~1.0",
                 "symfony/http-foundation": "~2.2",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/translation": "~2.0,>=2.0.5",
                 "symfony/validator": "~2.3.29"
             },
@@ -1699,7 +1703,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\Form\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1717,28 +1724,27 @@
             ],
             "description": "Symfony Form Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-25 21:41:39"
+            "time": "2015-11-23 10:02:49"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v2.7.4",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpFoundation.git",
-                "reference": "7253c2041652353e71560bbd300d6256d170ddaf"
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "e83a3d105ddaf5a113e803c904fdec552d1f1c35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpFoundation/zipball/7253c2041652353e71560bbd300d6256d170ddaf",
-                "reference": "7253c2041652353e71560bbd300d6256d170ddaf",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/e83a3d105ddaf5a113e803c904fdec552d1f1c35",
+                "reference": "e83a3d105ddaf5a113e803c904fdec552d1f1c35",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.4",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/expression-language": "~2.4"
             },
             "type": "library",
             "extra": {
@@ -1752,6 +1758,9 @@
                 },
                 "classmap": [
                     "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1770,21 +1779,21 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 06:45:45"
+            "time": "2015-11-20 17:41:18"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/HttpKernel",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/HttpKernel.git",
-                "reference": "15604f5b95a72ccdc38c318e14e9147e2e51bfa2"
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "a79bd3b40c73fd504d1e66ab6c40cdede509c600"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/HttpKernel/zipball/15604f5b95a72ccdc38c318e14e9147e2e51bfa2",
-                "reference": "15604f5b95a72ccdc38c318e14e9147e2e51bfa2",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/a79bd3b40c73fd504d1e66ab6c40cdede509c600",
+                "reference": "a79bd3b40c73fd504d1e66ab6c40cdede509c600",
                 "shasum": ""
             },
             "require": {
@@ -1803,7 +1812,6 @@
                 "symfony/dependency-injection": "~2.2",
                 "symfony/dom-crawler": "~2.0,>=2.0.5",
                 "symfony/finder": "~2.0,>=2.0.5",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/process": "~2.0,>=2.0.5",
                 "symfony/routing": "~2.2",
                 "symfony/stopwatch": "~2.3",
@@ -1826,7 +1834,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\HttpKernel\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1844,28 +1855,27 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-01 15:40:52"
+            "time": "2015-11-23 10:44:06"
         },
         {
             "name": "symfony/intl",
-            "version": "v2.7.4",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Intl.git",
-                "reference": "1a31df65b6c9c44b74cca31339f6ba0ce21e98f1"
+                "url": "https://github.com/symfony/intl.git",
+                "reference": "6c6c3aa69f68aff72e48a9bfc11f24680e23eb2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Intl/zipball/1a31df65b6c9c44b74cca31339f6ba0ce21e98f1",
-                "reference": "1a31df65b6c9c44b74cca31339f6ba0ce21e98f1",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/6c6c3aa69f68aff72e48a9bfc11f24680e23eb2d",
+                "reference": "6c6c3aa69f68aff72e48a9bfc11f24680e23eb2d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
             },
             "require-dev": {
-                "symfony/filesystem": "~2.1",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/filesystem": "~2.1"
             },
             "suggest": {
                 "ext-intl": "to use the component with locales other than \"en\""
@@ -1885,6 +1895,9 @@
                 ],
                 "files": [
                     "Resources/stubs/functions.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1919,20 +1932,20 @@
                 "l10n",
                 "localization"
             ],
-            "time": "2015-09-03 11:40:38"
+            "time": "2015-11-18 13:41:01"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.6.11",
+            "version": "v2.6.12",
             "target-dir": "Symfony/Component/OptionsResolver",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/OptionsResolver.git",
+                "url": "https://github.com/symfony/options-resolver.git",
                 "reference": "31e56594cee489e9a235b852228b0598b52101c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e56594cee489e9a235b852228b0598b52101c1",
                 "reference": "31e56594cee489e9a235b852228b0598b52101c1",
                 "shasum": ""
             },
@@ -1982,12 +1995,12 @@
             "target-dir": "Symfony/Component/Process",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Process.git",
+                "url": "https://github.com/symfony/process.git",
                 "reference": "be3cac4d0575bc547a0f2e85ceb4f19a5a8b3025"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/be3cac4d0575bc547a0f2e85ceb4f19a5a8b3025",
+                "url": "https://api.github.com/repos/symfony/process/zipball/be3cac4d0575bc547a0f2e85ceb4f19a5a8b3025",
                 "reference": "be3cac4d0575bc547a0f2e85ceb4f19a5a8b3025",
                 "shasum": ""
             },
@@ -2022,23 +2035,20 @@
         },
         {
             "name": "symfony/property-access",
-            "version": "v2.7.4",
+            "version": "v2.7.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/PropertyAccess.git",
-                "reference": "f8ea7aa472f0e3f8cdf43287caa72a70ff5c088c"
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "49d76463a54d8b3005fa58f3b8df41d0ae206eaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/PropertyAccess/zipball/f8ea7aa472f0e3f8cdf43287caa72a70ff5c088c",
-                "reference": "f8ea7aa472f0e3f8cdf43287caa72a70ff5c088c",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/49d76463a54d8b3005fa58f3b8df41d0ae206eaa",
+                "reference": "49d76463a54d8b3005fa58f3b8df41d0ae206eaa",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "~2.7"
             },
             "type": "library",
             "extra": {
@@ -2049,7 +2059,10 @@
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\PropertyAccess\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2078,21 +2091,21 @@
                 "property path",
                 "reflection"
             ],
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-11-18 13:41:01"
         },
         {
             "name": "symfony/routing",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/Routing",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Routing.git",
-                "reference": "fbadda8d2a35bdec8187bd54f698b8b704649721"
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "08a4065c47b45a1785101aabb29082fe415cec6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Routing/zipball/fbadda8d2a35bdec8187bd54f698b8b704649721",
-                "reference": "fbadda8d2a35bdec8187bd54f698b8b704649721",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/08a4065c47b45a1785101aabb29082fe415cec6c",
+                "reference": "08a4065c47b45a1785101aabb29082fe415cec6c",
                 "shasum": ""
             },
             "require": {
@@ -2103,7 +2116,6 @@
                 "psr/log": "~1.0",
                 "symfony/config": "~2.2",
                 "symfony/http-foundation": "~2.3",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/yaml": "~2.0,>=2.0.5"
             },
             "suggest": {
@@ -2120,7 +2132,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\Routing\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2138,7 +2153,7 @@
             ],
             "description": "Symfony Routing Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-01 19:33:42"
+            "time": "2015-11-18 08:19:46"
         },
         {
             "name": "symfony/templating",
@@ -2146,12 +2161,12 @@
             "target-dir": "Symfony/Component/Templating",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Templating.git",
+                "url": "https://github.com/symfony/templating.git",
                 "reference": "8c167181e5ea91c5d1c647059b40954225f83530"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Templating/zipball/8c167181e5ea91c5d1c647059b40954225f83530",
+                "url": "https://api.github.com/repos/symfony/templating/zipball/8c167181e5ea91c5d1c647059b40954225f83530",
                 "reference": "8c167181e5ea91c5d1c647059b40954225f83530",
                 "shasum": ""
             },
@@ -2186,17 +2201,17 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/Translation",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Translation.git",
-                "reference": "ef0c28743ddec8ae8bbba1993f7367df3d066f74"
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "7f01eb66bb0c677f30f5107a8848f8e1fc6ec9a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Translation/zipball/ef0c28743ddec8ae8bbba1993f7367df3d066f74",
-                "reference": "ef0c28743ddec8ae8bbba1993f7367df3d066f74",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7f01eb66bb0c677f30f5107a8848f8e1fc6ec9a7",
+                "reference": "7f01eb66bb0c677f30f5107a8848f8e1fc6ec9a7",
                 "shasum": ""
             },
             "require": {
@@ -2205,7 +2220,6 @@
             "require-dev": {
                 "symfony/config": "~2.3,>=2.3.12",
                 "symfony/intl": "~2.3",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/yaml": "~2.2"
             },
             "suggest": {
@@ -2221,7 +2235,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\Translation\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2239,7 +2256,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-26 09:54:34"
+            "time": "2015-11-18 08:19:46"
         },
         {
             "name": "symfony/twig-bridge",
@@ -2247,12 +2264,12 @@
             "target-dir": "Symfony/Bridge/Twig",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/TwigBridge.git",
+                "url": "https://github.com/symfony/twig-bridge.git",
                 "reference": "463814a95959a48719d2f2da953acac267afaf18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBridge/zipball/463814a95959a48719d2f2da953acac267afaf18",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/463814a95959a48719d2f2da953acac267afaf18",
                 "reference": "463814a95959a48719d2f2da953acac267afaf18",
                 "shasum": ""
             },
@@ -2313,17 +2330,17 @@
         },
         {
             "name": "symfony/twig-bundle",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Bundle/TwigBundle",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/TwigBundle.git",
-                "reference": "d507e06e6239ae35d90d8af357722bf0a233841c"
+                "url": "https://github.com/symfony/twig-bundle.git",
+                "reference": "dd08624d47ef8512ca222c0f034b17de96da8192"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/TwigBundle/zipball/d507e06e6239ae35d90d8af357722bf0a233841c",
-                "reference": "d507e06e6239ae35d90d8af357722bf0a233841c",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/dd08624d47ef8512ca222c0f034b17de96da8192",
+                "reference": "dd08624d47ef8512ca222c0f034b17de96da8192",
                 "shasum": ""
             },
             "require": {
@@ -2335,7 +2352,6 @@
                 "symfony/config": "~2.2",
                 "symfony/dependency-injection": "~2.2",
                 "symfony/framework-bundle": "~2.1",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/stopwatch": "~2.2",
                 "symfony/yaml": "~2.3"
             },
@@ -2348,7 +2364,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Bundle\\TwigBundle\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2366,21 +2385,21 @@
             ],
             "description": "Symfony TwigBundle",
             "homepage": "https://symfony.com",
-            "time": "2015-08-26 16:52:32"
+            "time": "2015-11-18 08:19:46"
         },
         {
             "name": "symfony/validator",
-            "version": "v2.3.32",
+            "version": "v2.3.35",
             "target-dir": "Symfony/Component/Validator",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Validator.git",
-                "reference": "ce542e83990ae8afa7c5562b6e19f124c6b288b8"
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "fbc64813991dbc7800aa46cfc3aa320627297582"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Validator/zipball/ce542e83990ae8afa7c5562b6e19f124c6b288b8",
-                "reference": "ce542e83990ae8afa7c5562b6e19f124c6b288b8",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/fbc64813991dbc7800aa46cfc3aa320627297582",
+                "reference": "fbc64813991dbc7800aa46cfc3aa320627297582",
                 "shasum": ""
             },
             "require": {
@@ -2392,7 +2411,6 @@
                 "symfony/config": "~2.2",
                 "symfony/http-foundation": "~2.1",
                 "symfony/intl": "~2.3",
-                "symfony/phpunit-bridge": "~2.7",
                 "symfony/yaml": "~2.0,>=2.0.5"
             },
             "suggest": {
@@ -2411,7 +2429,10 @@
             "autoload": {
                 "psr-0": {
                     "Symfony\\Component\\Validator\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2429,7 +2450,7 @@
             ],
             "description": "Symfony Validator Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-29 10:34:03"
+            "time": "2015-11-18 08:19:46"
         },
         {
             "name": "symfony/yaml",
@@ -2437,12 +2458,12 @@
             "target-dir": "Symfony/Component/Yaml",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
+                "url": "https://github.com/symfony/yaml.git",
                 "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/347a7a02204433c6926ecc3f13e805bdc30e8f9f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/347a7a02204433c6926ecc3f13e805bdc30e8f9f",
                 "reference": "347a7a02204433c6926ecc3f13e805bdc30e8f9f",
                 "shasum": ""
             },

--- a/src/EventListener/EVoucherListener.php
+++ b/src/EventListener/EVoucherListener.php
@@ -58,7 +58,6 @@ class EVoucherListener extends CogEvent\EventListener implements CogEvent\Subscr
 			$message = $this->get('translator')->trans($e->getTranslation(), $e->getParams());
 			$this->get('http.session')->getFlashBag()->add('error', $message);
 			$this->get('log.errors')->warning($e->getMessage());
-			throw $e;
 		}
 	}
 

--- a/src/EventListener/VoucherGenerateListener.php
+++ b/src/EventListener/VoucherGenerateListener.php
@@ -10,6 +10,7 @@ use Message\Mothership\Voucher\Loader as VoucherLoader;
 use Message\Mothership\Commerce\Order;
 use Message\Mothership\Commerce\Refund;
 
+use Message\User\AnonymousUser;
 use Message\Cog\ValueObject\DateTimeImmutable;
 use Message\Cog\Event\SubscriberInterface;
 
@@ -118,7 +119,9 @@ class VoucherGenerateListener implements SubscriberInterface
 		}
 		$voucher->id              = $this->_idGenerator->generate();
 		$voucher->purchasedAsItem = $item;
-		$voucher->authorship->create(new DateTimeImmutable, $item->order->user->id);
+		if ($item->order->user && !$item->order->user instanceof AnonymousUser) {
+			$voucher->authorship->create(new DateTimeImmutable, $item->order->user->id);
+		}
 
 		$this->_create->setTransaction($event->getTransaction());
 		$this->_create->create($voucher);

--- a/src/EventListener/VoucherGenerateListener.php
+++ b/src/EventListener/VoucherGenerateListener.php
@@ -5,13 +5,13 @@ namespace Message\Mothership\Voucher\EventListener;
 use Message\Mothership\Voucher\Voucher;
 use Message\Mothership\Voucher\Create;
 use Message\Mothership\Voucher\IdGenerator;
+use Message\Mothership\Voucher\Loader as VoucherLoader;
 
 use Message\Mothership\Commerce\Order;
 use Message\Mothership\Commerce\Refund;
 
-use Message\Cog\Event\EventListener;
+use Message\Cog\ValueObject\DateTimeImmutable;
 use Message\Cog\Event\SubscriberInterface;
-use Message\Mothership\Voucher\Loader as VoucherLoader;
 
 /**
  * Event listeners for generating vouchers.
@@ -118,6 +118,7 @@ class VoucherGenerateListener implements SubscriberInterface
 		}
 		$voucher->id              = $this->_idGenerator->generate();
 		$voucher->purchasedAsItem = $item;
+		$voucher->authorship->create(new DateTimeImmutable, $item->order->user->id);
 
 		$this->_create->setTransaction($event->getTransaction());
 		$this->_create->create($voucher);

--- a/src/Exception/EVoucherSendException.php
+++ b/src/Exception/EVoucherSendException.php
@@ -2,6 +2,15 @@
 
 namespace Message\Mothership\Voucher\Exception;
 
+/**
+ * Class EVoucherSendException
+ * @package Message\Mothership\Voucher\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * Exception to throw when an e-voucher cannot be distributed. Implements Cog's TranslationExceptionInterface
+ * so takes a second parameter of a translation string, and a third parameter of translation params.
+ */
 class EVoucherSendException extends VoucherDisplayException
 {
 

--- a/src/Exception/EVoucherSendException.php
+++ b/src/Exception/EVoucherSendException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Message\Mothership\Voucher\Exception;
+
+class EVoucherSendException extends VoucherDisplayException
+{
+
+}

--- a/src/Exception/VoucherDisplayException.php
+++ b/src/Exception/VoucherDisplayException.php
@@ -4,6 +4,14 @@ namespace Message\Mothership\Voucher\Exception;
 
 use Message\Cog\Exception\TranslationLogicException;
 
+/**
+ * Class VoucherDisplayException
+ * @package Message\Mothership\Voucher\Exception
+ *
+ * @author  Thomas Marchant <thomas@mothership.ec>
+ *
+ * General exception for displaying voucher-related errors as flash messages to users
+ */
 class VoucherDisplayException extends TranslationLogicException
 {
 

--- a/src/Exception/VoucherDisplayException.php
+++ b/src/Exception/VoucherDisplayException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Message\Mothership\Voucher\Exception;
+
+use Message\Cog\Exception\TranslationLogicException;
+
+class VoucherDisplayException extends TranslationLogicException
+{
+
+}

--- a/src/Validator.php
+++ b/src/Validator.php
@@ -146,13 +146,13 @@ class Validator
 			]);
 		}
 
-		if ($order !== null && !$this->isValidForOrder($voucher, $order)) {
+		if (null !== $order && !$this->isValidForOrder($voucher, $order)) {
 			return $this->_translator->trans(self::TRANS_KEY_NOT_VALID_FOR_ORDER, [
 				'%id%' => $voucher->id,
 			]);
 		}
 
-		if (!$this->isValidOnCurrency($voucher, $order)) {
+		if (null !== $order && !$this->isValidOnCurrency($voucher, $order)) {
 			return $this->_translator->trans(self::TRANS_KEY_NOT_VALID_FOR_CURRENCY, [
 				'%id%' => $voucher->id,
 			]);

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -39,6 +39,9 @@ ms.voucher:
       order-not-valid: Voucher '%id%' could not be applied to order - voucher not valid on this order.
       order-not-valid-currency: Voucher '%id%' could not be applied to order - voucher not valid in this currency.
   evoucher:
+    error:
+      email:
+        Could not send e-voucher, please make note of voucher code `%code%`
     email:
       subject: Thank you for purchasing an electronic gift voucher
       message:


### PR DESCRIPTION
This PR resolves an issue where the e-voucher was being sent to the customer too early in the process. It was being dispatched once a voucher had been created, rather than once the order was complete. This was causing an issue with SagePay integration as the gateway had no access to the session and therefore no access to the user, so could not send the email. What's worse is that this was a fatal error, and so the order would not be created, even though the money had been taken by the gateway. As a side note, emails were also being dispatched when creating a voucher manually in the admin panel.

Summary of changes:
- E-voucher dispatched on order completion, not on voucher creation
- User on order added to voucher at creation if possible
- Display flash message if no user is found on voucher, informing user of voucher code
- Deprecate `EVoucherListener::sendEVoucher()` method and remove from registry
- Fix Validator which was failing unit test
- Added exception classes, which are caught by event listener to generate flash message and log error in `error.log`
- Added `.travis.yml` file
